### PR TITLE
Remove / from 3rdparty in ome.viewportImage.js

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewportImage.js
@@ -42,12 +42,12 @@ jQuery.fn.viewportImage = function(options) {
     var panbars = options == null || options.panbars;
     var mediaroot = options == null ? null : options.mediaroot;
     mediaroot = mediaroot || '/appmedia';
-    
-    var $wb_zoomIn = $('<span class="wb_zoomIn" style="top: 10px;"><img src="'+mediaroot+'/3rdparty/panojs-2.0.0/images/32px_plus.png" title="Zoom in" style="width: 20px;"></span>')
+
+    var $wb_zoomIn = $('<span class="wb_zoomIn" style="top: 10px;"><img src="'+mediaroot+'3rdparty/panojs-2.0.0/images/32px_plus.png" title="Zoom in" style="width: 20px;"></span>')
                       .prependTo(wrapdiv);
-    var $wb_zoom11 = $('<span class="wb_zoom11" style="top: 40px;"><img src="'+mediaroot+'/3rdparty/panojs-2.0.0/images/32px_11.png" title="Zoom 1:1" style="width: 20px;"></span>')
+    var $wb_zoom11 = $('<span class="wb_zoom11" style="top: 40px;"><img src="'+mediaroot+'3rdparty/panojs-2.0.0/images/32px_11.png" title="Zoom 1:1" style="width: 20px;"></span>')
                       .prependTo(wrapdiv);
-    var $wb_zoomOut = $('<span class="wb_zoomOut" style="top: 70px;"><img src="'+mediaroot+'/3rdparty/panojs-2.0.0/images/32px_minus.png" title="Zoom out" style="width: 20px;"></span>')
+    var $wb_zoomOut = $('<span class="wb_zoomOut" style="top: 70px;"><img src="'+mediaroot+'3rdparty/panojs-2.0.0/images/32px_minus.png" title="Zoom out" style="width: 20px;"></span>')
                       .prependTo(wrapdiv);
 
     if (panbars) {


### PR DESCRIPTION
# What this PR does

Removes an extra `/` in front of some web assets which causes 404 errors in Docker
See https://trello.com/c/emmH0lCd/520-omeroweb-extraneous-forward-slash-for-static-asset-location

# Testing this PR

Build an omero-web-standalone Docker image: https://github.com/openmicroscopy/omero-web-docker/blob/master/standalone/Dockerfile

Open the built-in full image viewer (not iviewer). Check that the zoom icons (`+` +1:1` `-`) are shown: 
<img width="92" alt="screen shot 2019-01-24 at 17 39 57" src="https://user-images.githubusercontent.com/1644105/51697355-83cecb00-1fff-11e9-98ef-21acf1666bd1.png">
